### PR TITLE
Fix divers

### DIFF
--- a/class/usergroup_group.class.php
+++ b/class/usergroup_group.class.php
@@ -1,18 +1,18 @@
 <?php
 
 class TUserGroup_Group extends TObjetStd {
-	
-	
+
+
 	function __construct() { /* declaration */
 		global $langs;
 
 		parent::set_table(MAIN_DB_PREFIX.'usergroup_group');
 		parent::add_champs('entity,fk_group,fk_usergroup','type=entier;index;');
 		parent::add_champs('mode','type=chaine;index;');
-				
+
 		parent::_init_vars();
 		parent::start();
-		
+
 		$this->TMode=array(
 			'UNION'=>$langs->Trans('Union')
 			,'INTERSEC'=>$langs->Trans('Intersect')
@@ -21,16 +21,16 @@ class TUserGroup_Group extends TObjetStd {
 
 		$this->TGroup = array();
 	}
-	
+
 	static function getGroups(&$ATMdb, $fk_usergroup, $justId=false) {
 		global $conf,$db;
-		
+
 		dol_include_once('/user/class/usergroup.class.php');
-		
+
 		$TGroup=array('UNION'=>array(), 'INTERSEC'=>array());
 		$ATMdb->Execute("SELECT fk_group, mode FROM ".MAIN_DB_PREFIX."usergroup_group WHERE fk_usergroup=".(int)$fk_usergroup);
 		while($obj = $ATMdb->Get_line()) {
-			
+
 			if($justId) {
 				$TGroup[$obj->mode][] = $obj->fk_group;
 			}
@@ -39,118 +39,118 @@ class TUserGroup_Group extends TObjetStd {
 				$g->fetch($obj->fk_group);
 				if(empty($obj->mode))$obj->mode='UNION';
 				$TGroup[$obj->mode][] = $g;
-					
+
 			}
-			
+
 		}
-		
+
 		return $TGroup;
 	}
-	
+
 	static function getUsers(&$ATMdb, $fk_usergroup) {
-		
+
 		$TUser=null;
-	
+
 		$TGroup = TUserGroup_Group::getGroups($ATMdb, $fk_usergroup);
 
 		foreach($TGroup['UNION'] as $g) {
-			
+
 			$Tab = $g->listUsersForGroup('', 1);
-			
+
 			if(is_null($TUser))$TUser=$Tab;
 			else $TUser=array_merge($TUser, $Tab);
-			
+
 		}
-		
+
 		foreach($TGroup['INTERSEC'] as $g) {
 
 			$Tab = $g->listUsersForGroup('',1);
-			
+
 			if(is_null($TUser))$TUser=$Tab;
 			else $TUser=array_intersect($TUser, $Tab);
-			
+
 		}
-		
-		$TUser = array_unique($TUser, SORT_NUMERIC);
-		
+
+		if(!empty($TUser)) $TUser = array_unique($TUser, SORT_NUMERIC);
+
 		return $TUser;
 
 	}
-	
+
 	static function updateUserLink($ATMdb, $fk_usergroup, $notUsers=array()) {
 		global $db, $conf;
-	
+
 		if($fk_usergroup>0) {
 			$TUser = TUserGroup_Group::getUsers($ATMdb, $fk_usergroup);
-			
+
 			$g=new UserGroup($db);
 			$g->fetch($fk_usergroup);
 			$Tab = $g->listUsersForGroup('',1);
-			
+
 			foreach($TUser as $idu) {
-						
+
 				if(!in_array($idu, $Tab) && !in_array($idu, $notUsers)) {
-							
+
 					$u=new User($db);
 					$u->fetch($idu);
 					//print "ajout $idu $fk_usergroup<br/>";
 					$u->SetInGroup($fk_usergroup, $conf->entity);
-					
-				}	
-				
+
+				}
+
 			}
-			
+
 			foreach($Tab as $idu) {
-				
+
 				if(!in_array($idu, $TUser) && !in_array($idu, $notUsers)) {
-							
+
 					$u=new User($db);
 					$u->fetch($idu);
 					//print "suppr $idu $fk_usergroup<br/>";
 					$u->RemoveFromGroup($fk_usergroup, $conf->entity);
-					
-				}	
-				
-			}			
+
+				}
+
+			}
 		}
-		
+
 	}
-	
+
 	static function linkGroupUsersToAnother(&$ATMdb, $fk_group, $fk_usergroup=-1) {
 		global $conf,$db;
-		
+
 		$TGroupTo=array();
-		
+
 		if($fk_usergroup>0) {
 			$TGroupTo[] = $fk_usergroup;
 		}
 		else{
-			
+
 			// On récupère les groupes lié à ce groupe
 			$sql = "SELECT fk_usergroup FROM ".MAIN_DB_PREFIX."usergroup_group WHERE fk_group=".(int)$fk_group;
 			$ATMdb->Execute($sql);
 			while($obj = $ATMdb->Get_line()) {
 				$TGroupTo[] = $obj->fk_usergroup;
 			}
-				
-			
+
+
 		}
-		
-		
+
+
 		foreach ($TGroupTo as $id_group_to) {
 			// Pour chaque groupe on ajout les users du groupe courant dans ce dernier
 			TUserGroup_Group::updateUserLink($ATMdb, $id_group_to);
-			
+
 		}
-		
-	
-		
+
+
+
 	}
-	
+
 	static function linkGroupToAnother(&$ATMdb, $fk_group,$fk_usergroup=-1, $mode='UNION') {
 		global $conf,$db;
-		
-		if($fk_usergroup>0) {
+
+		if($fk_usergroup>0 && $fk_group > 0) {
 			$o=new TUserGroup_Group;
 			$o->fk_group = $fk_group;
 			$o->fk_usergroup = $fk_usergroup;
@@ -158,29 +158,29 @@ class TUserGroup_Group extends TObjetStd {
 			$o->mode = $mode;
 			$o->save($ATMdb);
 		}
-		
-		
+
+
 		TUserGroup_Group::linkGroupUsersToAnother($ATMdb, $fk_group, $fk_usergroup);
-		
+
 	}
-	
+
 	static function deleteLinkGroup(&$ATMdb, $fk_group, $fk_usergroup) {
 		global $db, $conf;
-		
+
 		$g=new UserGroup($db);
-			
+
 		$g->fetch($fk_group);
 		$Tab = $g->listUsersForGroup('',1);
 		foreach($Tab as $idUser=>$dummy) {
-			
+
 			$u=new User($db);
 			$u->fetch($idUser);
 			$u->RemoveFromGroup($fk_usergroup, $conf->entity);
 
 		}
-		
-		$ATMdb->Execute("DELETE FROM ".MAIN_DB_PREFIX."usergroup_group WHERE fk_usergroup=".(int)$fk_usergroup." AND fk_group=".(int)$fk_group);		
-		
+
+		$ATMdb->Execute("DELETE FROM ".MAIN_DB_PREFIX."usergroup_group WHERE fk_usergroup=".(int)$fk_usergroup." AND fk_group=".(int)$fk_group);
+
 	}
-	
+
 }

--- a/combine.php
+++ b/combine.php
@@ -1,32 +1,36 @@
 <?php
 
 	require('config.php');
-	
+
 	dol_include_once('/user/class/usergroup.class.php');
 	dol_include_once('/core/lib/usergroups.lib.php');
 	dol_include_once('/groupcombine/class/usergroup_group.class.php');
 
+   	$fk_group = GETPOST('fk_group');
+   	$id = GETPOST('id');
+   	$mode = GETPOST('mode');
+
 	$langs->load("users");
 	$langs->load("other");
 	$langs->load("groupcombine@groupcombine");
-	
+
 	llxHeader('',$langs->trans("GroupCard"));
-	
+
 	$action=GETPOST('action');
-	
+
 	$ATMdb=new TPDOdb;
-	
-	if($action==='addgroup') {
-		
-		TUserGroup_Group::linkGroupToAnother($ATMdb, GETPOST('fk_group'), GETPOST('id'), GETPOST('mode'));
-	
-		setEventMessage($langs->trans('GroupLinked'));	
+
+	if($action==='addgroup' && $fk_group > 0) {
+
+		TUserGroup_Group::linkGroupToAnother($ATMdb, $fk_group, $id, $mode);
+
+		setEventMessage($langs->trans('GroupLinked'));
 	}
 	else if($action==='dellink') {
-		TUserGroup_Group::deleteLinkGroup($ATMdb, GETPOST('fk_group'), GETPOST('id'));
+		TUserGroup_Group::deleteLinkGroup($ATMdb, $fk_group, $id);
 		setEventMessage($langs->trans('GroupLinkDeleted'));
 	}
-	
+
 	// Defini si peux lire/modifier utilisateurs et permisssions
 	$canreadperms=($user->admin || $user->rights->user->user->lire);
 	$caneditperms=($user->admin || $user->rights->user->user->creer);
@@ -38,22 +42,22 @@
 	    $caneditperms=($user->admin || $user->rights->user->group_advance->write);
 	    $candisableperms=($user->admin || $user->rights->user->group_advance->delete);
 	}
-		
-	
+
+
 	$result = restrictedArea($user, 'user', $id, 'usergroup&usergroup', 'user');
-	
+
 	print_fiche_titre($langs->trans("MultiGroup"));
-	
+
 	$object=new UserGroup($db);
 	$object->fetch(GETPOST('id'));
-	
+
 	$head = group_prepare_head($object);
     $title = $langs->trans("MultiGroup");
     dol_fiche_head($head, 'multigroup', $title, 0, 'group');
-	
-	
+
+
 	$form = new Form($db);
-	
+
 	print '<table class="border" width="100%">';
 
 			// Ref
@@ -89,34 +93,34 @@
 			print "</table>\n";
 
 			print '</div>';
-	
+
 			$ugg=new TUserGroup_Group;
 			$TGroupLinked = TUserGroup_Group::getGroups($ATMdb, $object->id, true);
-			
+
 			$formATM=new TFormCore('auto','formCG', 'post');
 			echo $formATM->hidden('action', 'addgroup');
 			echo $formATM->hidden('id', $object->id);
-	
+
 			echo $form->select_dolgroups(-1, 'fk_group',1, array_merge($TGroupLinked['UNION'],$TGroupLinked['INTERSEC'],array($object->id)) );
 			echo ' - '.$formATM->combo($langs->trans('MultiGroupMode'), 'mode', $ugg->TMode, 'INTERSEC' );
-			
+
 			echo $formATM->btsubmit($langs->trans('Add'), 'btadd');
-	
+
 			$formATM->end();
-			
-			
+
+
 			echo '<br />';
-	
+
 			$l=new TListviewTBS('listCombine');
-			
+
 			$sql = "SELECT ug.rowid as 'Id', ug.nom, ugg.mode, '' as 'Actions'
-			FROM ".MAIN_DB_PREFIX."usergroup_group ugg	LEFT JOIN ".MAIN_DB_PREFIX."usergroup ug ON (ugg.fk_group=ug.rowid) 
+			FROM ".MAIN_DB_PREFIX."usergroup_group ugg	LEFT JOIN ".MAIN_DB_PREFIX."usergroup ug ON (ugg.fk_group=ug.rowid)
 			WHERE ugg.fk_usergroup = ".$object->id."
 			ORDER BY  ug.nom
 			";
-						
+
 			print $l->render($ATMdb, $sql,array(
-			
+
 				'liste'=>array(
 					'titre'=>$langs->trans("ListOfGroupCombineInGroup")
 				)
@@ -125,44 +129,46 @@
 				)
 				,'link'=>array(
 					'Actions'=>'<a href="?action=dellink&fk_group=@Id@&id='.$object->id.'">'.img_delete().'</a>'
-					,'nom'=>img_picto('', 'object_group.png').' <a href="'.dol_buildpath('/user/group/fiche.php',1).'?id=@Id@">@val@</a>'
+					,'nom'=>img_picto('', 'object_group.png').' <a href="'.dol_buildpath('/user/group/card.php',1).'?id=@Id@">@val@</a>'
 				)
-				
+
 			));
-			
-			
-		print_fiche_titre($langs->trans("MultiGroupUserLinked"));	
-		
+
+
+		print_fiche_titre($langs->trans("MultiGroupUserLinked"));
+
 		?>
 		<table class="liste" width="100%">
 			<tr class="liste_titre">
 				<td class="liste_titre"><?php echo $langs->trans('User') ?></td>
 			</tr>
 			<?php
-			
+
 			$TUser = TUserGroup_Group::getUsers($ATMdb, $object->id);
+			if(!empty($TUser)) {
 			foreach($TUser as $idu) {
-								
+
 				$u=new User($db);
-				$u->fetch($idu);			
-							
-				$class = ($class =='impair') ? 'pair' : 'impair';		
-						
+				$u->fetch($idu);
+
+				$class = ($class =='impair') ? 'pair' : 'impair';
+
 				?><tr class="<?php echo $class ?>">
 					<td>
 						<?php echo $u->getNomUrl(1); ?>
 					</td>
 				</tr>
-				
+
 				<?php
-				
+
 			}
-			
+			}
+
 			?>
 		</table>
 		<?php
-	
-	
+
+
 	llxFooter();
 
-	
+

--- a/core/triggers/interface_99_modgroupcombine_groupcombinetrigger.class.php
+++ b/core/triggers/interface_99_modgroupcombine_groupcombinetrigger.class.php
@@ -116,32 +116,35 @@ class Interfacegroupcombinetrigger
         // Put here code you want to execute when a Dolibarr business events occurs.
         // Data and type of action are stored into $object and $action
         // Users
-       if ($action === 'USER_SETINGROUP') {
-       	
+       if ($action === 'USER_SETINGROUP' || $action === 'USER_MODIFY') {
+
 			define('INC_FROM_DOLIBARR', true);
 		    dol_include_once('/groupcombine/config.php');
 			dol_include_once('/groupcombine/class/usergroup_group.class.php');
-			
-			
-			$fk_group = $object->newgroupid;
-			$ATMdb=new TPDOdb;
-			TUserGroup_Group::linkGroupUsersToAnother($ATMdb, $fk_group);
-						
+
+
+	       $fk_group = $object->newgroupid;
+	       if (empty($fk_group) && !empty($object->context['newgroupid'])) $fk_group = $object->context['newgroupid'];
+	       if (empty($fk_group) && !empty($object->context['oldgroupid'])) $fk_group = $object->context['oldgroupid'];
+
+	       $ATMdb = new TPDOdb;
+	       TUserGroup_Group::linkGroupUsersToAnother($ATMdb, $fk_group);
+
 			dol_syslog(
                 "Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id
             );
-        } 
+        }
         elseif ($action === 'USER_REMOVEFROMGROUP') {
-        	
+
 			define('INC_FROM_DOLIBARR', true);
 		    dol_include_once('/groupcombine/config.php');
 			dol_include_once('/groupcombine/class/usergroup_group.class.php');
-			
+
 			$fk_group = $object->oldgroupid; // Groupe d'où l'utilisateur a déjà été enlevé
 			$ATMdb=new TPDOdb;
 			//TUserGroup_Group::updateUserLink($ATMdb, $fk_group, array($object->id));
 			TUserGroup_Group::linkGroupUsersToAnother($ATMdb, $fk_group);
-			
+
             dol_syslog(
                 "Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id
             );


### PR DESCRIPTION
Anomalie 1 :
Lorsque je vais dans l'onglet "Multi-groupe" d'un groupe, si je clique sur "Ajouter" sans choisir un groupe, cela ajoute une ligne (vide). Il est ensuite impossible de la supprimer.

Anomalie 2 :
Lors de l'ajout de groupe dans l'onglet multi-groupe, le lien vers ces groupes dans la liste renvoie vers un page 404 (l'url renvoie vers fiche.php au lieu de card.php)

Anomalie 3 :
Lorsqu'un utilisateur est ajouté à deux groupes correspondant au filtre multi-groupe d'un troisième groupe, il n'est pas ajouté "réellemennt" à ce groupe